### PR TITLE
Allow the app to boot optionally without creds

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {edoc_opts, [{dir, "edoc"}]}.
-{deps, [{aws_erlang, "master",
+{deps, [{aws, "master",
          {git, "https://github.com/jkakar/aws-erlang.git",
           {branch, "master"}}},
         {iso8601, ".*",

--- a/src/aws_metadata.app.src
+++ b/src/aws_metadata.app.src
@@ -6,9 +6,12 @@
   {applications,
    [kernel,
     stdlib,
-    aws
+    aws,
+    hackney
    ]},
-  {env,[]},
+  {env,[
+    {fail_if_unavailable, true}
+  ]},
   {modules, []},
 
   {contributors, []},

--- a/src/aws_metadata_client.erl
+++ b/src/aws_metadata_client.erl
@@ -19,7 +19,7 @@ fetch_role() ->
     hackney:body(ClientRef).
 
 fetch_metadata(Role) ->
-    {ok, 200, _, ClientRef} = hackney:get([?CREDENTIAL_URL, Role]),
+    {ok, 200, _, ClientRef} = hackney:get(iolist_to_binary([?CREDENTIAL_URL, Role])),
     {ok, Body} = hackney:body(ClientRef),
     Map = jsx:decode(Body, [return_maps]),
     {ok, maps:get(<<"AccessKeyId">>, Map),


### PR DESCRIPTION
In some cases, the application could be used as part of a dual scheme
where the app is used as a primary mechanism but where a failover
authentication scheme exists.

In such cases, wanting the app not to go down entirely when AWS metadata
is available, but instead returning `undefined`, can be desireable.

This patch adds a configuration value that optionally allows the app not
to fail on boot when AWS metadata isn't available.

Other changes:
- Rename 'aws_erlang' in rebar.config to 'aws', the actual app name, so
  that dialyzer and other tools can properly find it.
- Change the URL input to talk with hackney to a binary() from an
  iolist() following Dialyzer recommendations.
