### PR TITLE
Return temporary clients

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 [{<<"aws">>,
   {git,"https://github.com/jkakar/aws-erlang.git",
-       {ref,"42a243d3ab9c3b0d1095bed50ba1c31d3d7dbce2"}},
+       {ref,"7be0fc4aab0ea757d8f3aa497ca7621dd2f877d4"}},
   0},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.15.0">>},1},
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.0.6">>},1},

--- a/src/aws_metadata_client.erl
+++ b/src/aws_metadata_client.erl
@@ -9,9 +9,9 @@
 
 fetch() ->
     {ok, Role} = fetch_role(),
-    {ok, AccessKeyID, SecretAccessKey, ExpirationTime} = fetch_metadata(Role),
+    {ok, AccessKeyID, SecretAccessKey, ExpirationTime, Token} = fetch_metadata(Role),
     {ok, Region} = fetch_document(),
-    Client = aws_client:make_client(AccessKeyID, SecretAccessKey, Region),
+    Client = aws_client:make_temporary_client(AccessKeyID, SecretAccessKey, Token, Region),
     {ok, Client, ExpirationTime}.
 
 fetch_role() ->
@@ -24,7 +24,8 @@ fetch_metadata(Role) ->
     Map = jsx:decode(Body, [return_maps]),
     {ok, maps:get(<<"AccessKeyId">>, Map),
      maps:get(<<"SecretAccessKey">>, Map),
-     maps:get(<<"Expiration">>, Map)}.
+     maps:get(<<"Expiration">>, Map),
+     maps:get(<<"Token">>, Map)}.
 
 fetch_document() ->
     {ok, 200, _, ClientRef} = hackney:get(?DOCUMENT_URL),

--- a/test/aws_metadata_SUITE.erl
+++ b/test/aws_metadata_SUITE.erl
@@ -26,6 +26,7 @@ init_per_group(mecked_metadata, Config) ->
     SecretAccessKey = <<"SecretAccessKey">>,
     Expiry = <<"2019-09-25T23:43:56Z">>,
     Region = <<"ap-southeast-1">>,
+    Token = <<"token">>,
     CredentialsBody = <<"{
       \"Code\" : \"Success\",
       \"LastUpdated\" : \"2015-09-25T17:19:52Z\",
@@ -69,6 +70,7 @@ init_per_group(mecked_metadata, Config) ->
     [{access_key, AccessKeyID},
      {secret_key, SecretAccessKey},
      {expiry, Expiry},
+     {token, Token},
      {region, Region}|Config];
 init_per_group(boot, Config) ->
     meck:new(aws_metadata_client, [no_link, passthrough]),
@@ -101,7 +103,8 @@ test_get_client(Config) ->
     AccessKeyID = ?config(access_key, Config),
     SecretAccessKey = ?config(secret_key, Config),
     Region = ?config(region, Config),
-    Client = aws_client:make_client(AccessKeyID, SecretAccessKey, Region),
+    Token = ?config(token, Config),
+    Client = aws_client:make_temporary_client(AccessKeyID, SecretAccessKey, Token, Region),
     ?assertMatch(Client, aws_metadata:get_client()).
 
 fail_boot(_Config) ->


### PR DESCRIPTION
For instance metadata, temporary clients need to be supported to
properly submit request tokens.
